### PR TITLE
New flags and updated to V6 PIA servers json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+This is a fork https://github.com/kylegrantlucas/pia-wg-config original script.
+
+I have updated it to use the latest PIA API and added the flag `--server, -s` which will add the server's common name to the config file. This is useful for adding it to Gluetun for port-forwarding.
+
 # pia-wg-config
 
 A Wireguard config generator for Private Internet Access.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 This is a fork https://github.com/kylegrantlucas/pia-wg-config original script.
 
-I have updated it to use the latest PIA API and added the flag `--server, -s` which will add the server's common name to the config file. This is useful for adding it to Gluetun for port-forwarding.
+I have updated it to use the latest PIA server lists. In addition added the following flags:
+
+- `--server, -s` which will add the server's common name to the config file
+- `--port-fowarding, -p` which will force the script to only use servers that support port forwarding. I haven't edge-cased this yet, so providing a server that doesn't support port forwarding may cause the script to fail.
+
+This is useful for adding it to Gluetun for port-forwarding. Additionally changed default PIA region to ca_toronto as this region supports port forwarding.
 
 # pia-wg-config
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Wireguard config generator for Private Internet Access.
 
 ## Usage
 
-`go install github.com/kylegrantlucas/pia-wg-config@latest`
+`go install github.com/Ephemeral-Dust/pia-wg-config@latest`
 
 `pia-wg-config -o wg0.conf USERNAME PASSWORD`
 
@@ -12,7 +12,7 @@ You can now use `wg0.conf` to connect using your favorite wireguard client.
 
 ## Background
 
-Based off of the [manual-connections](https://github.com/pia-foss/manual-connections) scripts provided FOSS by Private Internet Access. 
+Based off of the [manual-connections](https://github.com/pia-foss/manual-connections) scripts provided FOSS by Private Internet Access.
 
 Golang was chosen to provide stability and portability to the scripts.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Ephemeral-Dust/pia-wg-config
 
-go 1.21.3
+go 1.21
 
 require (
 	github.com/benburkert/dns v0.0.0-20190225204957-d356cf78cdfc

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kylegrantlucas/pia-wg-config
+module github.com/Ephemeral-Dust/pia-wg-config
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Ephemeral-Dust/pia-wg-config
 
-go 1.19
+go 1.21.3
 
 require (
 	github.com/benburkert/dns v0.0.0-20190225204957-d356cf78cdfc

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ github.com/benburkert/dns v0.0.0-20190225204957-d356cf78cdfc/go.mod h1:6ul4nJKqs
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
@@ -14,5 +15,6 @@ github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsr
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 h1:kUhD7nTDoI3fVd9G4ORWrbV5NY0liEs/Jg2pv5f+bBA=
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20220916014741-473347a5e6e3 h1:ARxNdT6I+00ZyY5yRT/ZECkQti4iGrMZX9dvG/ao/LY=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20220916014741-473347a5e6e3/go.mod h1:yp4gl6zOlnDGOZeWeDfMwQcsdOIQnMdhuPx9mwwWBL4=

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 			&cli.StringFlag{
 				Name:    "region",
 				Aliases: []string{"r"},
-				Value:   "us_california",
+				Value:   "ca_toronto",
 				Usage:   "The private internet access region to connect to",
 			},
 			&cli.BoolFlag{
@@ -37,6 +37,12 @@ func main() {
 				Aliases: []string{"s"},
 				Value:   false,
 				Usage:   "Add Server common name to the config",
+			},
+			&cli.BoolFlag{
+				Name:    "port-forwarding",
+				Aliases: []string{"p"},
+				Value:   false,
+				Usage:   "Only get servers with port forwarding enabled",
 			},
 		},
 	}
@@ -52,12 +58,13 @@ func defaultAction(c *cli.Context) error {
 	password := c.Args().Get(1)
 	verbose := c.Bool("verbose")
 	serverName := c.Bool("server")
+	portForwarding := c.Bool("port-forwarding")
 
 	// create pia client
 	if verbose {
 		log.Print("Creating PIA client")
 	}
-	piaClient, err := pia.NewPIAClient(username, password, c.String("region"), verbose)
+	piaClient, err := pia.NewPIAClient(username, password, c.String("region"), verbose, portForwarding)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/kylegrantlucas/pia-wg-config/pia"
+	"github.com/Ephemeral-Dust/pia-wg-config/pia"
 	cli "github.com/urfave/cli/v2"
 )
 
@@ -32,6 +32,12 @@ func main() {
 				Value:   false,
 				Usage:   "Print verbose output",
 			},
+			&cli.BoolFlag{
+				Name:    "server",
+				Aliases: []string{"s"},
+				Value:   false,
+				Usage:   "Add Server common name to the config",
+			},
 		},
 	}
 
@@ -45,6 +51,13 @@ func defaultAction(c *cli.Context) error {
 	username := c.Args().Get(0)
 	password := c.Args().Get(1)
 	verbose := c.Bool("verbose")
+	serverName := c.Bool("server")
+
+	log.Printf("Username: %s\n", username)
+	log.Printf("Password: %s\n", password)
+	log.Printf("Region: %s\n", c.String("region"))
+	log.Printf("Verbose: %v\n", verbose)
+	log.Printf("Server: %v\n", serverName)
 
 	// create pia client
 	if verbose {
@@ -59,7 +72,7 @@ func defaultAction(c *cli.Context) error {
 	if verbose {
 		log.Print("creating wg config generator")
 	}
-	wgConfigGenerator := pia.NewPIAWgGenerator(piaClient, pia.PIAWgGeneratorConfig{Verbose: verbose})
+	wgConfigGenerator := pia.NewPIAWgGenerator(piaClient, pia.PIAWgGeneratorConfig{Verbose: verbose, ServerName: serverName})
 
 	// generate wg config
 	if verbose {

--- a/main.go
+++ b/main.go
@@ -53,12 +53,6 @@ func defaultAction(c *cli.Context) error {
 	verbose := c.Bool("verbose")
 	serverName := c.Bool("server")
 
-	log.Printf("Username: %s\n", username)
-	log.Printf("Password: %s\n", password)
-	log.Printf("Region: %s\n", c.String("region"))
-	log.Printf("Verbose: %v\n", verbose)
-	log.Printf("Server: %v\n", serverName)
-
 	// create pia client
 	if verbose {
 		log.Print("Creating PIA client")

--- a/pia/pia.go
+++ b/pia/pia.go
@@ -96,10 +96,8 @@ func NewPIAClient(username, password, region string, verbose bool) (*PIAClient, 
 // GetToken
 func (p *PIAClient) GetToken() (string, error) {
 	server := p.getMetadataServerForRegion()
-	log.Print("Getting token from server: ", server.Cn)
 
 	url := fmt.Sprintf("https://%v/authv3/generateToken", server.Cn)
-	log.Print("Requesting token from: ", url)
 
 	// Send request
 	resp, err := p.executePIARequest(server, url, "")
@@ -222,33 +220,25 @@ func (p *PIAClient) generateMetadataServerList(list piaServerList) ServerList {
 }
 
 func (p *PIAClient) executePIARequest(server Server, url, token string) (*http.Response, error) {
-	// Log the URL being requested
-	log.Printf("Request URL: %s", url)
-
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		log.Printf("Error creating request: %v", err)
 		return nil, err
 	}
 
 	// Set header to JSON
 	req.Header.Set("Content-Type", "application/json")
-	log.Printf("Request Headers: %v", req.Header)
 
 	// Set basic auth
 	if token == "" {
 		req.SetBasicAuth(p.username, p.password)
-		log.Printf("Using Basic Auth with username: %s", p.username)
-	} else {
-		log.Printf("Using token: %s", token)
 	}
 
 	// Add certificate to shared pool
 	err = p.downloadPIACertificate()
 	if err != nil {
-		log.Printf("Error downloading CA certificate: %v", err)
 		return nil, errors.Wrap(err, "error downloading ca certificate")
 	}
+
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(p.caCert)
 
@@ -291,27 +281,17 @@ func (p *PIAClient) executePIARequest(server Server, url, token string) (*http.R
 		},
 	}
 
-	// Log the server details
-	log.Printf("Requesting server: %s (%s)", server.Cn, server.IP)
-
 	// Execute the request
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Printf("Error executing request: %v", err)
 		return nil, err
 	}
-
-	// Log the response status and headers
-	log.Printf("Response Status: %s", resp.Status)
-	log.Printf("Response Headers: %v", resp.Header)
 
 	// Log the response body
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Printf("Error reading response body: %v", err)
 		return nil, err
 	}
-	log.Printf("Response Body: %s", string(body))
 	resp.Body = io.NopCloser(bytes.NewReader(body))
 
 	// Return error if status code is not 200

--- a/pia/wg_test.go
+++ b/pia/wg_test.go
@@ -6,6 +6,14 @@ import (
 
 type PIAClientMock struct{}
 
+func (p *PIAClientMock) getMetadataServerForRegion() Server {
+	// Mock implementation for getMetadataServerForRegion
+	return Server{
+		Cn: "mock-server",
+		IP: "0.0.0.0",
+	}
+}
+
 func (p *PIAClientMock) GetToken() (string, error) {
 	return "", nil
 }
@@ -26,6 +34,7 @@ func TestPIAWgGenerator_Generate(t *testing.T) {
 		verbose    bool
 		privatekey string
 		publickey  string
+		serverName bool ``
 	}
 	tests := []struct {
 		name    string
@@ -39,6 +48,7 @@ func TestPIAWgGenerator_Generate(t *testing.T) {
 				pia: &PIAClientMock{},
 				config: PIAWgGeneratorConfig{
 					Verbose:    false,
+					ServerName: false,
 					PrivateKey: "test_privatekey",
 					PublicKey:  "test_publickey",
 				},
@@ -52,6 +62,29 @@ PublicKey = test_publickey
 AllowedIPs = 0.0.0.0/0
 Endpoint = 1.2.3.4:1337
 PersistentKeepalive = 25`,
+			wantErr: false,
+		},
+		{
+			name: "generate with serverCommonName",
+			fields: fields{
+				pia: &PIAClientMock{},
+				config: PIAWgGeneratorConfig{
+					Verbose:    false,
+					ServerName: true,
+					PrivateKey: "test_privatekey",
+					PublicKey:  "test_publickey",
+				},
+			},
+			want: `[Interface]
+PrivateKey = test_privatekey
+Address = 4.5.6.7
+DNS = 1.1.1.1
+[Peer]
+PublicKey = test_publickey
+AllowedIPs = 0.0.0.0/0
+Endpoint = 1.2.3.4:1337
+PersistentKeepalive = 25
+ServerCommonName = mock-server`,
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
Due to the last update being 3 years ago I assume this project isn't maintained but wanted to offer the PR in-case  you do want to merge it. 

Added the following flags:

- `--server, -s` which will add the server's common name to the config file
- `--port-fowarding, -p` which will force the script to only use servers that support port forwarding. I haven't edge-cased this yet, so providing a server that doesn't support port forwarding may cause the script to fail.

This is useful for adding it to Gluetun for port-forwarding. Additionally changed default PIA region to ca_toronto as this region supports port forwarding.