### PR TITLE
Update README with Go installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,33 @@ This will show you the complete list of PIA server regions you can connect to.
 
 ## 🚀 Quick Start
 
-### Installation
+### Install Go
+
+#### Linux
+
+```bash
+sudo apt-get update && sudo apt-get install golang-go
+
+# define go installation location and add to path
+go env -w GOPATH=$HOME/go
+echo "export GOPATH=\$HOME/go" >> ~/.bash_profile
+echo "export PATH=\$PATH:\$GOPATH/bin" >> ~/.bash_profile
+source ~/.bash_profile
+```
+
+#### macOS
+
+```bash
+brew install go
+
+# define go installation location and add to path
+go env -w GOPATH=$HOME/go
+echo "export GOPATH=\$HOME/go" >> ~/.zshenv
+echo "export PATH=\$PATH:\$GOPATH/bin" >> ~/.zshenv
+source ~/.zshenv
+```
+
+### Install pia-wg-config
 
 ```bash
 go install github.com/kylegrantlucas/pia-wg-config@latest


### PR DESCRIPTION
Love this project! It's crazy that PIA still hasn't added a feature to download a WireGuard profile.

Anyways, I had never messed with go before, and it took me a bit to understand how to install it and (more importantly) setup the appropriate environment variables.

Therefore, I added some basic installation instructions for Go on Linux and macOS. Debatable if that kind of info belongs in a README, but it was helpful to me! (btw I tested these instructions on macOS but not linux directly).